### PR TITLE
[Do Not Merge] ElasticSearch Flexibility

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.3.0
+version: 1.4.0
 appVersion: 6.3.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `cluster.xpackEnable`                | Writes the X-Pack configuration options to the configuration file   | `false`                              |
 | `cluster.config`                     | Additional cluster config appended                                  | `{}`                                 |
 | `cluster.env`                        | Cluster environment variables                                       | `{}`                                 |
+| `cluster.shortDiscoveryURI`          | Use shortened URI as discovery service                              | `{}`                                 |
 | `cluster.routingAttributes`          | Cluster routing attributes                                          | `nil`                                |
 | `cluster.slowlogEnable`              | Enable Slowlog Logging                                              | `false`                              |
 | `cluster.gclogEnable`                | Enable GC Logging                                                   | `false`                              |
@@ -130,6 +131,8 @@ In terms of Memory resources you should make sure that you follow that equation:
 - `${role}HeapSize < ${role}MemoryRequests < ${role}MemoryLimits`
 
 The YAML value of cluster.config is appended to elasticsearch.yml file for additional customization ("script.inline: on" for example to allow inline scripting)
+
+If `cluster.shortDiscoveryURI` is provided `{{ elasticsearch.fullname }}-discovery.{{ .Relase.Namespace }}` will be as the $DISCOVERY_SERVICE.
 
 # Deep dive
 

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `cluster.xpackEnable`                | Writes the X-Pack configuration options to the configuration file   | `false`                              |
 | `cluster.config`                     | Additional cluster config appended                                  | `{}`                                 |
 | `cluster.env`                        | Cluster environment variables                                       | `{}`                                 |
-| `cluster.routing_attributes`         | Cluster routing attributes                                          | `nil`                                |
+| `cluster.routingAttributes`          | Cluster routing attributes                                          | `nil`                                |
 | `cluster.slowlogEnable`              | Enable Slowlog Logging                                              | `false`                              |
 | `cluster.gclogEnable`                | Enable GC Logging                                                   | `false`                              |
 | `client.name`                        | Client component name                                               | `client`                             |
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.resources`                   | Client node resources requests & limits                             | `{} - cpu limit must be an integer`  |
 | `client.priorityClassName`           | Client priorityClass                                                | `nil`                                |
 | `client.heapSize`                    | Client node heap size                                               | `512m`                               |
-| `client.java.opts_equal`             | Client node java `-<key>=<value>` options                           | `{}`                                 |
+| `client.java.optsEqual`              | Client node java `-<key>=<value>` options                           | `{}`                                 |
 | `client.java.opts`                   | Client node java `-<key><value>` options                            | `{}`                                 |
 | `client.podAnnotations`              | Client Deployment annotations                                       | `{}`                                 |
 | `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
@@ -95,7 +95,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.nodeSelector`                | Node labels for master pod assignment                               | `{}`                                 |
 | `master.tolerations`                 | Master tolerations                                                  | `{}`                                 |
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
-| `master.java.opts_equal`             | Master node java `-<key>=<value>` options                           | `{}`                                 |
+| `master.java.optsEqual`              | Master node java `-<key>=<value>` options                           | `{}`                                 |
 | `master.java.opts`                   | Master node java `-<key><value>` options                            | `{}`                                 |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
@@ -108,7 +108,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.priorityClassName`             | Data priorityClass                                                  | `nil`                                |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |
-| `data.java.opts_equal`               | Data node java `-<key>=<value>` options                             | `{}`                                 |
+| `data.java.optsEqual`                | Data node java `-<key>=<value>` options                             | `{}`                                 |
 | `data.java.opts`                     | Data node java `-<key><value>` options                              | `{}`                                 |
 | `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                               |
 | `data.persistence.name`              | Data statefulset PVC template name                                  | `data`                               |

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -71,6 +71,9 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `cluster.xpackEnable`                | Writes the X-Pack configuration options to the configuration file   | `false`                              |
 | `cluster.config`                     | Additional cluster config appended                                  | `{}`                                 |
 | `cluster.env`                        | Cluster environment variables                                       | `{}`                                 |
+| `cluster.routing_attributes`         | Cluster routing attributes                                          | `nil`                                |
+| `cluster.slowlogEnable`              | Enable Slowlog Logging                                              | `false`                              |
+| `cluster.gclogEnable`                | Enable GC Logging                                                   | `false`                              |
 | `client.name`                        | Client component name                                               | `client`                             |
 | `client.replicas`                    | Client node replicas (deployment)                                   | `2`                                  |
 | `client.resources`                   | Client node resources requests & limits                             | `{} - cpu limit must be an integer`  |
@@ -117,6 +120,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.tolerations`                   | Data tolerations                                                    | `{}`                                 |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
+| `index`                              | Index/Action Configuration (Ex. index.number_of_shards)             | `{}`                                 |
+| `plugins`                            | Mandadtory Plugins                                                  | `[]`                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -130,7 +135,7 @@ The YAML value of cluster.config is appended to elasticsearch.yml file for addit
 
 ## Application Version
 
-This chart aims to support Elasticsearch v2 and v5 deployments by specifying the `values.yaml` parameter `appVersion`.
+This chart aims to support Elasticsearch v1, v2, v5 and v6 deployments by specifying the `values.yaml` parameter `appVersion`.
 
 ### Version Specific Features
 

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -76,6 +76,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.resources`                   | Client node resources requests & limits                             | `{} - cpu limit must be an integer`  |
 | `client.priorityClassName`           | Client priorityClass                                                | `nil`                                |
 | `client.heapSize`                    | Client node heap size                                               | `512m`                               |
+| `client.java.opts_equal`             | Client node java `-<key>=<value>` options                           | `{}`                                 |
+| `client.java.opts`                   | Client node java `-<key><value>` options                            | `{}`                                 |
 | `client.podAnnotations`              | Client Deployment annotations                                       | `{}`                                 |
 | `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
 | `client.tolerations`                 | Client tolerations                                                  | `{}`                                 |
@@ -90,6 +92,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.nodeSelector`                | Node labels for master pod assignment                               | `{}`                                 |
 | `master.tolerations`                 | Master tolerations                                                  | `{}`                                 |
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
+| `master.java.opts_equal`             | Master node java `-<key>=<value>` options                           | `{}`                                 |
+| `master.java.opts`                   | Master node java `-<key><value>` options                            | `{}`                                 |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
 | `master.persistence.name`            | Master statefulset PVC template name                                | `data`                               |
@@ -101,6 +105,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.priorityClassName`             | Data priorityClass                                                  | `nil`                                |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |
+| `data.java.opts_equal`               | Data node java `-<key>=<value>` options                             | `{}`                                 |
+| `data.java.opts`                     | Data node java `-<key><value>` options                              | `{}`                                 |
 | `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                               |
 | `data.persistence.name`              | Data statefulset PVC template name                                  | `data`                               |
 | `data.persistence.size`              | Data persistent volume size                                         | `30Gi`                               |

--- a/incubator/elasticsearch/templates/_elasticsearch.yml.tpl
+++ b/incubator/elasticsearch/templates/_elasticsearch.yml.tpl
@@ -1,7 +1,7 @@
 {{ define "elasticsearch.yml" -}}
 cluster.name: {{ .Values.cluster.name }}
-{{ if .Values.cluster.routing_attributes }}
-cluster.routing.allocation.awareness.attributes: {{ .Values.cluster.routing_attributes }}
+{{ if .Values.cluster.routingAttributes }}
+cluster.routing.allocation.awareness.attributes: {{ .Values.cluster.routingAttributes }}
 {{ end }}
 
 node.data: ${NODE_DATA:true}

--- a/incubator/elasticsearch/templates/_elasticsearch.yml.tpl
+++ b/incubator/elasticsearch/templates/_elasticsearch.yml.tpl
@@ -119,4 +119,4 @@ monitor.jvm.gc.young.info: ${GC_LOG_YOUNG_INFO:700ms}
 monitor.jvm.gc.young.warn: ${GC_LOG_YOUNG_WARN:1s}
 {{- end }}
 
-{{ end-}}
+{{ end -}}

--- a/incubator/elasticsearch/templates/_elasticsearch.yml.tpl
+++ b/incubator/elasticsearch/templates/_elasticsearch.yml.tpl
@@ -1,4 +1,5 @@
 {{ define "elasticsearch.yml" -}}
+
 cluster.name: {{ .Values.cluster.name }}
 {{ if .Values.cluster.routingAttributes }}
 cluster.routing.allocation.awareness.attributes: {{ .Values.cluster.routingAttributes }}

--- a/incubator/elasticsearch/templates/_elasticsearch.yml.tpl
+++ b/incubator/elasticsearch/templates/_elasticsearch.yml.tpl
@@ -1,0 +1,122 @@
+{{ define "elasticsearch.yml" -}}
+cluster.name: {{ .Values.cluster.name }}
+{{ if .Values.cluster.routing_attributes }}
+cluster.routing.allocation.awareness.attributes: {{ .Values.cluster.routing_attributes }}
+{{ end }}
+
+node.data: ${NODE_DATA:true}
+node.master: ${NODE_MASTER:true}
+{{- if hasPrefix "5." .Values.appVersion }}
+node.ingest: ${NODE_INGEST:true}
+{{- else if hasPrefix "6." .Values.appVersion }}
+node.ingest: ${NODE_INGEST:true}
+{{- end }}
+node.name: ${HOSTNAME}
+
+network.host: 0.0.0.0
+transport.tcp.port: 9300
+http.port: 9200
+
+{{- if hasPrefix "1." .Values.appVersion }}
+# see https://github.com/kubernetes/kubernetes/issues/3595
+bootstrap.mlockall: ${BOOTSTRAP_MLOCKALL:false}
+
+discovery:
+  zen:
+    ping.unicast.hosts: ${DISCOVERY_SERVICE:}
+    minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
+
+{{- else if hasPrefix "2." .Values.appVersion }}
+# see https://github.com/kubernetes/kubernetes/issues/3595
+bootstrap.mlockall: ${BOOTSTRAP_MLOCKALL:false}
+
+discovery:
+  zen:
+    ping.unicast.hosts: ${DISCOVERY_SERVICE:}
+    minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
+{{- else if hasPrefix "5." .Values.appVersion }}
+# see https://github.com/kubernetes/kubernetes/issues/3595
+bootstrap.memory_lock: ${BOOTSTRAP_MEMORY_LOCK:false}
+
+discovery:
+  zen:
+    ping.unicast.hosts: ${DISCOVERY_SERVICE:}
+    minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
+
+{{- if .Values.cluster.xpackEnable }}
+# see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
+xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
+xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
+xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
+{{- end }}
+{{- else if hasPrefix "6." .Values.appVersion }}
+# see https://github.com/kubernetes/kubernetes/issues/3595
+bootstrap.memory_lock: ${BOOTSTRAP_MEMORY_LOCK:false}
+
+discovery:
+  zen:
+    ping.unicast.hosts: ${DISCOVERY_SERVICE:}
+    minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
+
+{{- if .Values.cluster.xpackEnable }}
+# see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
+xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
+xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
+xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
+{{- end }}
+{{- end }}
+
+# see https://github.com/elastic/elasticsearch-definitive-guide/pull/679
+processors: ${PROCESSORS:}
+
+# avoid split-brain w/ a minimum consensus of two masters plus a data node
+gateway.expected_master_nodes: ${EXPECTED_MASTER_NODES:2}
+gateway.expected_data_nodes: ${EXPECTED_DATA_NODES:1}
+gateway.recover_after_time: ${RECOVER_AFTER_TIME:5m}
+gateway.recover_after_master_nodes: ${RECOVER_AFTER_MASTER_NODES:2}
+gateway.recover_after_data_nodes: ${RECOVER_AFTER_DATA_NODES:1}
+{{- if .Values.cluster.config }}
+{{ toYaml .Values.cluster.config . }}
+{{- end }}
+
+
+# indices configuration
+{{- if .Values.index }}
+index:
+{{ toYaml .Values.index | indent 2 }}
+{{- end }}
+
+# additional plugins
+{{ if .Values.plugins }}
+plugin.mandatory: {{ $.Value.plugins | join ", " }}
+{{ end }}
+
+# slowlog logging
+{{- if .Values.cluster.slowlogEnable }}
+index.indexing.slowlog.threshold.index.trace: ${SLOWLOG_INDEXING_TRACE:500ms}
+index.indexing.slowlog.threshold.index.debug: ${SLOWLOG_INDEXING_DEBUG:2s}
+index.indexing.slowlog.threshold.index.info: ${SLOWLOG_INDEXING_INFO:5s}
+index.indexing.slowlog.threshold.index.warn: ${SLOWLOG_INDEXING_WARN:10s}
+index.search.slowlog.threshold.fetch.trace: ${SLOWLOG_SEARCH_FETCH_TRACE:200ms}
+index.search.slowlog.threshold.fetch.debug: ${SLOWLOG_SEARCH_FETCH_DEBUG:500ms}
+index.search.slowlog.threshold.fetch.info: ${SLOWLOG_SEARCH_FETCH_INFO:800ms}
+index.search.slowlog.threshold.fetch.warn: ${SLOWLOG_SEARCH_FETCH_WARN:1s}
+index.search.slowlog.threshold.query.trace: ${SLOWLOG_SEARCH_QUERY_TRACE:500ms}
+index.search.slowlog.threshold.query.debug: ${SLOWLOG_SEARCH_QUERY_DEBUG:2s}
+index.search.slowlog.threshold.query.info: ${SLOWLOG_SEARCH_QUERY_INFO:5s}
+index.search.slowlog.threshold.query.warn: ${SLOWLOG_SEARCH_QUERY_WARN:10s}
+{{- end }}
+
+# gc logging
+{{- if .Values.cluster.gclogEnable }}
+monitor.jvm.gc.old.debug: ${GC_LOG_OLD_DEBUG:2s}
+monitor.jvm.gc.old.info: ${GC_LOG_OLD_INFO:5s}
+monitor.jvm.gc.old.warn: ${GC_LOG_OLD_WARN:10s}
+monitor.jvm.gc.young.debug: ${GC_LOG_YOUNG_DEBUG:400ms}
+monitor.jvm.gc.young.info: ${GC_LOG_YOUNG_INFO:700ms}
+monitor.jvm.gc.young.warn: ${GC_LOG_YOUNG_WARN:1s}
+{{- end }}
+
+{{ end-}}

--- a/incubator/elasticsearch/templates/_helpers.tpl
+++ b/incubator/elasticsearch/templates/_helpers.tpl
@@ -54,8 +54,8 @@ We can add custom overrides here.
 `opts_equals` are applied with `-` prefix and `=` option. Ex. `foo: bar` -> `-foo=bar`
 `opts` are applied with `-` prefix and without a `=`. Ex. `foo: bar` -> `-foobar`
 */}}
-{{- define "elasticsearch.client.java_opts" -}}
--Djava.net.preferIPv4Stack=true {{ if .Values.client.heapSize }}-Xms{{ .Values.client.heapSize }} -Xmx{{ .Values.client.heapSize }}{{ end }}{{- range $opt, $val := .Values.client.java.opts_equals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.client.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
+{{- define "elasticsearch.client.javaOpts" -}}
+-Djava.net.preferIPv4Stack=true {{ if .Values.client.heapSize }}-Xms{{ .Values.client.heapSize }} -Xmx{{ .Values.client.heapSize }}{{ end }}{{- range $opt, $val := .Values.client.java.optsEquals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.client.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
 {{- end -}}
 
 {{/*
@@ -65,8 +65,8 @@ We can add custom overrides here.
 `opts_equals` are applied with `-` prefix and `=` option. Ex. `foo: bar` -> `-foo=bar`
 `opts` are applied with `-` prefix and without a `=`. Ex. `foo: bar` -> `-foobar`
 */}}
-{{- define "elasticsearch.master.java_opts" -}}
--Djava.net.preferIPv4Stack=true {{ if .Values.master.heapSize }}-Xms{{ .Values.master.heapSize }} -Xmx{{ .Values.master.heapSize }}{{ end }}{{- range $opt, $val := .Values.master.java.opts_equals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.master.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
+{{- define "elasticsearch.master.javaOpts" -}}
+-Djava.net.preferIPv4Stack=true {{ if .Values.master.heapSize }}-Xms{{ .Values.master.heapSize }} -Xmx{{ .Values.master.heapSize }}{{ end }}{{- range $opt, $val := .Values.master.java.optsEquals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.master.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
 {{- end -}}
 
 {{/*
@@ -76,6 +76,6 @@ We can add custom overrides here.
 `opts_equals` are applied with `-` prefix and `=` option. Ex. `foo: bar` -> `-foo=bar`
 `opts` are applied with `-` prefix and without a `=`. Ex. `foo: bar` -> `-foobar`
 */}}
-{{- define "elasticsearch.data.java_opts" -}}
--Djava.net.preferIPv4Stack=true {{ if .Values.data.heapSize }}-Xms{{ .Values.data.heapSize }} -Xmx{{ .Values.data.heapSize }}{{ end }}{{- range $opt, $val := .Values.data.java.opts_equals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.data.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
+{{- define "elasticsearch.data.javaOpts" -}}
+-Djava.net.preferIPv4Stack=true {{ if .Values.data.heapSize }}-Xms{{ .Values.data.heapSize }} -Xmx{{ .Values.data.heapSize }}{{ end }}{{- range $opt, $val := .Values.data.java.optsEquals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.data.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
 {{- end -}}

--- a/incubator/elasticsearch/templates/_helpers.tpl
+++ b/incubator/elasticsearch/templates/_helpers.tpl
@@ -46,3 +46,36 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "elasticsearch.master.fullname" -}}
 {{ template "elasticsearch.fullname" . }}-{{ .Values.master.name }}
 {{- end -}}
+
+{{/*
+Create the default client node java opts
+We can add custom overrides here.
+
+`opts_equals` are applied with `-` prefix and `=` option. Ex. `foo: bar` -> `-foo=bar`
+`opts` are applied with `-` prefix and without a `=`. Ex. `foo: bar` -> `-foobar`
+*/}}
+{{- define "elasticsearch.client.java_opts" -}}
+-Djava.net.preferIPv4Stack=true {{ if .Values.client.heapSize }}-Xms{{ .Values.client.heapSize }} -Xmx{{ .Values.client.heapSize }}{{ end }}{{- range $opt, $val := .Values.client.java.opts_equals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.client.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
+{{- end -}}
+
+{{/*
+Create the default master node java opts
+We can add custom overrides here.
+
+`opts_equals` are applied with `-` prefix and `=` option. Ex. `foo: bar` -> `-foo=bar`
+`opts` are applied with `-` prefix and without a `=`. Ex. `foo: bar` -> `-foobar`
+*/}}
+{{- define "elasticsearch.master.java_opts" -}}
+-Djava.net.preferIPv4Stack=true {{ if .Values.master.heapSize }}-Xms{{ .Values.master.heapSize }} -Xmx{{ .Values.master.heapSize }}{{ end }}{{- range $opt, $val := .Values.master.java.opts_equals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.master.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
+{{- end -}}
+
+{{/*
+Create the default data node java opts
+We can add custom overrides here.
+
+`opts_equals` are applied with `-` prefix and `=` option. Ex. `foo: bar` -> `-foo=bar`
+`opts` are applied with `-` prefix and without a `=`. Ex. `foo: bar` -> `-foobar`
+*/}}
+{{- define "elasticsearch.data.java_opts" -}}
+-Djava.net.preferIPv4Stack=true {{ if .Values.data.heapSize }}-Xms{{ .Values.data.heapSize }} -Xmx{{ .Values.data.heapSize }}{{ end }}{{- range $opt, $val := .Values.data.java.opts_equals }}-{{ $opt }}={{ $val }} {{- end}} {{- range $opt, $val := .Values.data.java.opts }}-{{ $opt }}{{ $val }} {{- end}}
+{{- end -}}

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -78,7 +78,11 @@ spec:
         - name: NODE_MASTER
           value: "false"
         - name: DISCOVERY_SERVICE
+        {{- if .Values.cluster.shortDiscoveryURI }}
+          value: {{ template "elasticsearch.fullname" . }}-discovery.{{ .Release.Namespace }}
+        {{- else }}
           value: {{ template "elasticsearch.fullname" . }}-discovery.{{ .Release.Namespace }}.svc.{{ .Values.cluster.kubernetesDomain }}
+        {{- end }}
         - name: PROCESSORS
           valueFrom:
             resourceFieldRef:

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -84,7 +84,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: {{ template "elasticsearch.client.java_opts" . }}
+          value: {{ template "elasticsearch.client.javaOpts" . }}
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -84,7 +84,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.client.heapSize }} -Xmx{{ .Values.client.heapSize }}"
+          value: {{ template "elasticsearch.client.java_opts" . }}
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/templates/configmap.yaml
+++ b/incubator/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   elasticsearch.yml: |-
-    {{ include "elasticsearch.yml" . | indent 4 }}
+{{ include "elasticsearch.yml" . | indent 4 }}
 {{- if hasPrefix "2." .Values.image.tag }}
   logging.yml: |-
     # you can override this using by setting a system property, for example -Des.logger.level=DEBUG

--- a/incubator/elasticsearch/templates/configmap.yaml
+++ b/incubator/elasticsearch/templates/configmap.yaml
@@ -9,73 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   elasticsearch.yml: |-
-    cluster.name: {{ .Values.cluster.name }}
-
-    node.data: ${NODE_DATA:true}
-    node.master: ${NODE_MASTER:true}
-{{- if hasPrefix "5." .Values.appVersion }}
-    node.ingest: ${NODE_INGEST:true}
-{{- else if hasPrefix "6." .Values.appVersion }}
-    node.ingest: ${NODE_INGEST:true}
-{{- end }}
-    node.name: ${HOSTNAME}
-
-    network.host: 0.0.0.0
-
-{{- if hasPrefix "2." .Values.appVersion }}
-    # see https://github.com/kubernetes/kubernetes/issues/3595
-    bootstrap.mlockall: ${BOOTSTRAP_MLOCKALL:false}
-
-    discovery:
-      zen:
-        ping.unicast.hosts: ${DISCOVERY_SERVICE:}
-        minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
-{{- else if hasPrefix "5." .Values.appVersion }}
-    # see https://github.com/kubernetes/kubernetes/issues/3595
-    bootstrap.memory_lock: ${BOOTSTRAP_MEMORY_LOCK:false}
-
-    discovery:
-      zen:
-        ping.unicast.hosts: ${DISCOVERY_SERVICE:}
-        minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
-
-{{- if .Values.cluster.xpackEnable }}
-    # see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
-    xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
-    xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
-    xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
-    xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
-{{- end }}
-{{- else if hasPrefix "6." .Values.appVersion }}
-    # see https://github.com/kubernetes/kubernetes/issues/3595
-    bootstrap.memory_lock: ${BOOTSTRAP_MEMORY_LOCK:false}
-
-    discovery:
-      zen:
-        ping.unicast.hosts: ${DISCOVERY_SERVICE:}
-        minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
-
-{{- if .Values.cluster.xpackEnable }}
-    # see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
-    xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
-    xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
-    xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
-    xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
-{{- end }}
-{{- end }}
-
-    # see https://github.com/elastic/elasticsearch-definitive-guide/pull/679
-    processors: ${PROCESSORS:}
-
-    # avoid split-brain w/ a minimum consensus of two masters plus a data node
-    gateway.expected_master_nodes: ${EXPECTED_MASTER_NODES:2}
-    gateway.expected_data_nodes: ${EXPECTED_DATA_NODES:1}
-    gateway.recover_after_time: ${RECOVER_AFTER_TIME:5m}
-    gateway.recover_after_master_nodes: ${RECOVER_AFTER_MASTER_NODES:2}
-    gateway.recover_after_data_nodes: ${RECOVER_AFTER_DATA_NODES:1}
-{{- if .Values.cluster.config }}
-{{ toYaml .Values.cluster.config | indent 4 }}
-{{- end }}
+    {{ include "elasticsearch.yml" . | indent 4 }}
 {{- if hasPrefix "2." .Values.image.tag }}
   logging.yml: |-
     # you can override this using by setting a system property, for example -Des.logger.level=DEBUG

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -92,7 +92,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: {{ template "elasticsearch.data.java_opts" . }}
+          value: {{ template "elasticsearch.data.javaOpts" . }}
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -84,7 +84,11 @@ spec:
       - name: elasticsearch
         env:
         - name: DISCOVERY_SERVICE
+          {{- if .Values.cluster.shortDiscoveryURI }}
+          value: {{ template "elasticsearch.fullname" . }}-discovery.{{ .Release.Namespace }}
+          {{- else }}
           value: {{ template "elasticsearch.fullname" . }}-discovery.{{ .Release.Namespace }}.svc.{{ .Values.cluster.kubernetesDomain }}
+          {{- end }}
         - name: NODE_MASTER
           value: "false"
         - name: PROCESSORS

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -92,7 +92,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.data.heapSize }} -Xmx{{ .Values.data.heapSize }}"
+          value: {{ template "elasticsearch.data.java_opts" . }}
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -90,7 +90,11 @@ spec:
           value: "false"
 {{- end }}
         - name: DISCOVERY_SERVICE
+          {{- if .Values.cluster.shortDiscoveryURI }}
+          value: {{ template "elasticsearch.fullname" . }}-discovery.{{ .Release.Namespace }}
+          {{- else }}
           value: {{ template "elasticsearch.fullname" . }}-discovery.{{ .Release.Namespace }}.svc.{{ .Values.cluster.kubernetesDomain }}
+          {{- end }}
         - name: PROCESSORS
           valueFrom:
             resourceFieldRef:

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -96,7 +96,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: {{ template "elasticsearch.master.java_opts" . }}
+          value: {{ template "elasticsearch.master.javaOpts" . }}
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -96,7 +96,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.master.heapSize }} -Xmx{{ .Values.master.heapSize }}"
+          value: {{ template "elasticsearch.master.java_opts" . }}
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -8,7 +8,10 @@ image:
   tag: "6.3.1"
   pullPolicy: "IfNotPresent"
 
-plugins: {}
+# if using the plugins feature, be sure to switch to an image that includes the plugins you require.
+plugins: []
+
+# index specifies index sharding and creation rules.
 index: {}
 
 cluster:

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -35,7 +35,7 @@ client:
 #    example: client-svc-foo
   heapSize: "512m"
   java:
-    opts_equal: {}
+    optsEqual: {}
     opts: {}
   antiAffinity: "soft"
   nodeSelector: {}
@@ -58,7 +58,7 @@ master:
   replicas: 3
   heapSize: "512m"
   java:
-    opts_equal: {}
+    optsEqual: {}
     opts: {}
   persistence:
     enabled: true
@@ -87,7 +87,7 @@ data:
   replicas: 2
   heapSize: "1536m"
   java:
-    opts_equal: {}
+    optsEqual: {}
     opts: {}
   persistence:
     enabled: true

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -8,12 +8,17 @@ image:
   tag: "6.3.1"
   pullPolicy: "IfNotPresent"
 
+plugins: {}
+index: {}
+
 cluster:
   name: "elasticsearch"
   kubernetesDomain: cluster.local
   # If you want X-Pack installed, switch to an image that includes it, enable this option and toggle the features you want
   # enabled in the environment variables outlined in the README
   xpackEnable: false
+  slowlogEnable: false
+  gclogEnable: false
   config:
   env:
     # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes
@@ -29,6 +34,9 @@ client:
 #  serviceAnnotations:
 #    example: client-svc-foo
   heapSize: "512m"
+  java:
+    opts_equal: {}
+    opts: {}
   antiAffinity: "soft"
   nodeSelector: {}
   tolerations: {}
@@ -49,6 +57,9 @@ master:
   exposeHttp: false
   replicas: 3
   heapSize: "512m"
+  java:
+    opts_equal: {}
+    opts: {}
   persistence:
     enabled: true
     accessMode: ReadWriteOnce
@@ -75,6 +86,9 @@ data:
   exposeHttp: false
   replicas: 2
   heapSize: "1536m"
+  java:
+    opts_equal: {}
+    opts: {}
   persistence:
     enabled: true
     accessMode: ReadWriteOnce


### PR DESCRIPTION
**DO NOT MERGE**
This PR is meant to flush out all the bits necessary for a flexible uniform ES chart that we can use from 1.x->6.x+

**What this PR does / why we need it:**
We wanted some more flexibility on the runtime options for ElasticSearch. Mostly refactors elasticsearch.yml into it's own template as a number of additional settings were added.

This will support 1.x line if custom images are provided.

**Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):**

fixes #

**Special notes for your reviewer:**

This is still a WIP, trying to get some quick feedback.